### PR TITLE
FIX: Indicate the imported is a type.

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -1,4 +1,4 @@
-import { paths } from './types';
+import type { paths } from './types';
 
 /** 条目 */
 export namespace BGMSubjectParams {

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,4 @@
-import { paths } from './types';
+import type { paths } from './types';
 
 /** 条目 */
 export namespace BGMSubject {


### PR DESCRIPTION
fixed: if `verbatimModuleSyntax` is enabled in tsconfig.json, the project will fail to compile. We should indicate it as a type when be imported.

---

如果项目中 `tsconfig.json` 配置文件的 `verbatimModuleSyntax` 字段启用后，无法编译通过，因为该字段要求明确指明导出的是否为类型（指明为类型后，编译器便会自动剔除相关语句来减少输出）。